### PR TITLE
fix: load global user sdl mappings for pyxel core

### DIFF
--- a/Engine and Runtime/opt/muos/script/launch/ext-pyxel.sh
+++ b/Engine and Runtime/opt/muos/script/launch/ext-pyxel.sh
@@ -13,6 +13,8 @@ FILE=${3%/}
 	LOG_INFO "$0" 0 "FILE" "$FILE"
 ) &
 
+SETUP_SDL_ENVIRONMENT
+
 HOME="$(GET_VAR "device" "board/home")"
 export HOME
 
@@ -27,9 +29,8 @@ else
 fi
 
 SDL_JOYSTICK_DEVICE="/dev/input/js0"
-SDL_GAMECONTROLLERCONFIG="19000000010000000100000000010000,muOS-Keys,platform:Linux,a:b3,b:b4,x:b5,y:b6,back:b9,start:b10,leftshoulder:b7,rightshoulder:b8,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,lefttrigger:b13,righttrigger:b14"
 
-export SDL_HQ_SCALER SDL_ROTATION SDL_BLITTER_DISABLED SDL_JOYSTICK_DEVICE SDL_GAMECONTROLLERCONFIG
+export SDL_HQ_SCALER SDL_ROTATION SDL_BLITTER_DISABLED SDL_JOYSTICK_DEVICE
 
 # Check if "pyxel" is already installed
 if ! /usr/bin/python3 -c "import pyxel" 2>/dev/null; then


### PR DESCRIPTION
This change ensures that Pyxel apps on muOS use the same, tested controller mappings that work for other applications, rather than relying on hardcoded configurations.

Pyxel app used to test
```python
import pyxel as px


class App:
    def __init__(self):
        px.init(width=240, height=160, title="Hello World", fps=30)
        self.text = "Press a button"
        px.run(self.update, self.draw)

    def update(self):
        if px.btnp(px.GAMEPAD1_BUTTON_A):
            self.text = "A"
        elif px.btnp(px.GAMEPAD1_BUTTON_B):
            self.text = "B"
        elif px.btnp(px.GAMEPAD1_BUTTON_X):
            self.text = "X"
        elif px.btnp(px.GAMEPAD1_BUTTON_Y):
            self.text = "Y"

        elif px.btnp(px.GAMEPAD1_BUTTON_DPAD_UP):
            self.text = "UP"
        elif px.btnp(px.GAMEPAD1_BUTTON_DPAD_DOWN):
            self.text = "DOWN"
        elif px.btnp(px.GAMEPAD1_BUTTON_DPAD_LEFT):
            self.text = "LEFT"
        elif px.btnp(px.GAMEPAD1_BUTTON_DPAD_RIGHT):
            self.text = "RIGHT"

        elif px.btnp(px.GAMEPAD1_BUTTON_LEFTSHOULDER):
            self.text = "LEFT SHOULDER"
        elif px.btnp(px.GAMEPAD1_BUTTON_RIGHTSHOULDER):
            self.text = "RIGHT SHOULDER"

        elif px.btnp(px.GAMEPAD1_BUTTON_GUIDE):
            self.text = "MENU"
            px.quit()

        elif px.btnp(px.GAMEPAD1_BUTTON_BACK):
            self.text = "SELECT"
        elif px.btnp(px.GAMEPAD1_BUTTON_START):
            self.text = "START"

    def draw(self):
        px.cls(0)

        # Draw header banner
        banner_height = 11
        banner_text = "Hello World"
        px.rect(0, 0, px.width, banner_height, px.COLOR_DARK_BLUE)

        # Center text in the banner
        x = (px.width // 2) - ((len(banner_text) * px.FONT_WIDTH) // 2)
        y = (banner_height // 2) - (px.FONT_HEIGHT // 2)
        px.text(x, y, banner_text, px.COLOR_WHITE)

        # Center text in the screen
        x = (px.width // 2) - ((len(self.text) * px.FONT_WIDTH) // 2)
        y = (px.height - banner_height) // 2 + (px.FONT_HEIGHT // 2)
        px.text(x, y, self.text, px.COLOR_WHITE)


if __name__ == "__main__":
    App()
```

<img width="1024" height="768" alt="muOS_20250831_2254_0" src="https://github.com/user-attachments/assets/a66d1bf3-8b29-4d8b-884e-6679f6a0ee64" />
